### PR TITLE
공연 검색 기능 구현 

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,7 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="30" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -3,7 +3,10 @@
   <component name="MaterialThemeProjectNewConfig">
     <option name="metadata">
       <MTProjectMetadataState>
-        <option name="userId" value="45867f31:19410cab03a:-7ffd" />
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="5489bec1:18fc3ef6812:-8000" />
+        <option name="version" value="8.13.2" />
       </MTProjectMetadataState>
     </option>
   </component>

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/controller/Performance.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/controller/Performance.kt
@@ -1,8 +1,32 @@
 package com.wafflestudio.interpark.performance.controller
 
-data class Performance (
+import com.wafflestudio.interpark.performance.persistence.PerformanceEntity
+import java.time.LocalDate
+
+data class Performance(
+    val id: String,
     val title: String,
-
-){
-
+    val hallName: String,
+    val dates: List<LocalDate>,
+    val genre: String,
+    val detail: String,
+    val sales: Int,
+    val posterUrl: String,
+    val backdropUrl: String,
+) {
+    companion object {
+        fun fromEntity(entity: PerformanceEntity): Performance {
+            return Performance(
+                id = entity.id ?: "",
+                title = entity.title,
+                hallName = entity.hall.name,
+                dates = entity.dates,
+                genre = entity.genre,
+                detail = entity.detail ?: "",
+                sales = entity.sales,
+                posterUrl = entity.posterUrl,
+                backdropUrl = entity.backdropUrl,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/controller/PerformanceController.kt
@@ -1,2 +1,25 @@
 package com.wafflestudio.interpark.performance.controller
 
+import com.wafflestudio.interpark.performance.service.PerformanceService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+class PerformanceController(
+    private val performanceService: PerformanceService,
+) {
+    @GetMapping("v1/performance/search")
+    fun searchPerformance(
+        @RequestParam keyword: String,
+        @RequestParam sortType: Int,
+        @RequestParam(required = false) date: LocalDate?,
+        @RequestParam(required = false) region: String?,
+        @RequestParam(required = false) genre: String?,
+    ): ResponseEntity<List<Performance>> {
+        val queriedPerformances = performanceService.searchPerformance(keyword, sortType, date, region, genre)
+        return ResponseEntity.ok(queriedPerformances)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceEntity.kt
@@ -1,12 +1,46 @@
 package com.wafflestudio.interpark.performance.persistence
 
-import jakarta.persistence.*
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import java.time.LocalDate
 
 @Entity(name = "performances")
-class PerformanceEntity (
+class PerformanceEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     val id: String? = null,
-
-    val detail: String? = null
+    @ManyToOne
+    @JoinColumn(name = "hall_id", nullable = false)
+    var hall: PerformanceHallEntity,
+    @Column(nullable = false)
+    var title: String,
+    @Column(columnDefinition = "TEXT")
+    var detail: String? = null,
+    @Column(nullable = false)
+    var genre: String,
+    @Column(nullable = false)
+    var sales: Int = 0,
+    @ElementCollection
+    @CollectionTable(name = "performance_dates", joinColumns = [JoinColumn(name = "performance_id")])
+    @Column(name = "date", nullable = false)
+    var dates: List<LocalDate> = mutableListOf(),
+    @Column(name = "poster_url", nullable = false)
+    var posterUrl: String,
+    @Column(name = "backdrop_url", nullable = false)
+    var backdropUrl: String,
+    @ElementCollection
+    @CollectionTable(name = "performance_seats", joinColumns = [JoinColumn(name = "performance_id")])
+    @Column(name = "seat_id", nullable = false)
+    var seatIds: List<String> = mutableListOf(),
+    @ElementCollection
+    @CollectionTable(name = "performance_reviews", joinColumns = [JoinColumn(name = "performance_id")])
+    @Column(name = "review_id", nullable = false)
+    var reviewIds: List<String> = mutableListOf(),
 )

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceHallEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceHallEntity.kt
@@ -1,0 +1,4 @@
+package com.wafflestudio.interpark.performance.persistence
+
+class PerformanceHallEntity {
+}

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceHallEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceHallEntity.kt
@@ -1,4 +1,20 @@
 package com.wafflestudio.interpark.performance.persistence
 
-class PerformanceHallEntity {
-}
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "performance_hall")
+class PerformanceHallEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: String? = null,
+    @Column(nullable = false)
+    var name: String,
+    @Column(nullable = false)
+    var address: String,
+)

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceHallRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceHallRepository.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.interpark.performance.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PerformanceHallRepository : JpaRepository<PerformanceHallEntity, String>

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceRepository.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.interpark.performance.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+
+interface PerformanceRepository :
+    JpaRepository<PerformanceEntity, String>,
+    JpaSpecificationExecutor<PerformanceEntity>

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceSpecifications.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/persistence/PerformanceSpecifications.kt
@@ -1,0 +1,64 @@
+package com.wafflestudio.interpark.performance.persistence
+
+import jakarta.persistence.criteria.JoinType
+import org.springframework.data.jpa.domain.Specification
+import java.time.LocalDate
+
+object PerformanceSpecifications {
+    /**
+     * 키워드(검색어) 필수: PerformanceEntity.title 또는 detail 에 매칭되는지
+     * - 정확도 순이라는 것이 '키워드 매칭'을 의미한다고 가정
+     */
+    fun withKeyword(keyword: String): Specification<PerformanceEntity> {
+        return Specification { root, query, cb ->
+            if (keyword.isBlank()) {
+                // 검색어가 비어있다면 전체 반환(조건 없음)
+                cb.conjunction()
+            } else {
+                val likeKeyword = "%$keyword%"
+                cb.or(
+                    cb.like(root.get("title"), likeKeyword),
+                    cb.like(root.get("detail"), likeKeyword),
+                )
+            }
+        }
+    }
+
+    /**
+     * 날짜 필터(선택): 해당 날짜를 포함하는 공연이 있는지
+     * - date가 공연 dates 컬렉션에 포함되어 있어야 함
+     * - 특정 날짜가 아닌, 날짜 범위가 필요하다면 추가로 수정
+     */
+    fun withDate(date: LocalDate?): Specification<PerformanceEntity>? {
+        if (date == null) return null
+
+        return Specification { root, query, cb ->
+            // dates 컬렉션에 date 값이 포함되어 있으면 true
+            cb.isMember(date, root.get("dates"))
+        }
+    }
+
+    /**
+     * 지역 필터(선택): PerformanceHallEntity의 address 컬럼 안에 region 문자열이 포함
+     */
+    fun withRegion(region: String?): Specification<PerformanceEntity>? {
+        if (region.isNullOrBlank()) return null
+
+        return Specification { root, query, cb ->
+            val hallJoin = root.join<PerformanceEntity, PerformanceHallEntity>("hall", JoinType.LEFT)
+            cb.like(hallJoin.get("address"), "%$region%")
+        }
+    }
+
+    /**
+     * 장르 필터(선택): 이제 PerformanceEntity의 genre 컬럼을 직접 비교
+     *  (예: 부분 매칭으로 하려면 cb.like(root.get("genre"), "%$genre%") 로 수정)
+     */
+    fun withGenre(genre: String?): Specification<PerformanceEntity>? {
+        if (genre.isNullOrBlank()) return null
+
+        return Specification { root, _, cb ->
+            cb.equal(root.get<String>("genre"), genre)
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/interpark/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/performance/service/PerformanceService.kt
@@ -1,3 +1,73 @@
 package com.wafflestudio.interpark.performance.service
 
-class PerformanceService
+import com.wafflestudio.interpark.performance.controller.Performance
+import com.wafflestudio.interpark.performance.persistence.PerformanceEntity
+import com.wafflestudio.interpark.performance.persistence.PerformanceRepository
+import com.wafflestudio.interpark.performance.persistence.PerformanceSpecifications
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
+import java.time.LocalDate
+
+class PerformanceService(
+    private val performanceRepository: PerformanceRepository,
+) {
+    fun searchPerformance(
+        keyword: String,
+        sortType: Int,
+        date: LocalDate?,
+        region: String?,
+        genre: String?,
+    ): List<Performance> {
+        // 기본 스펙(키워드 검색은 필수)
+        var spec: Specification<PerformanceEntity> = Specification.where(PerformanceSpecifications.withKeyword(keyword))
+
+        // 날짜가 있으면 스펙 추가
+        PerformanceSpecifications.withDate(date)?.let {
+            spec = spec.and(it)
+        }
+
+        // 지역이 있으면 스펙 추가
+        PerformanceSpecifications.withRegion(region)?.let {
+            spec = spec.and(it)
+        }
+
+        // 장르가 있으면 스펙 추가
+        PerformanceSpecifications.withGenre(genre)?.let {
+            spec = spec.and(it)
+        }
+
+        // 정렬 기준
+        // 1. 정확도순: 일단 예시상 '정확도'라는 것은 키워드 매칭 스코어 기반 정렬이 필요하지만,
+        //    여기서는 정렬로 처리하기 애매하므로 title 기준 정렬 or 별도 검색엔진(ElasticSearch)이 필요.
+        //    간단히 title 오름차순 정렬로 가정하겠습니다.
+        // 2. 공연임박순: dates 중 가장 빠른 날짜를 기준으로 오름차순 정렬
+        // 3. 많이 팔린 순 : 판매량(sales) 기준 내림차순 정렬 (실제로 sales라는 컬럼이 있어야 함)
+        //
+        // 실무에서는 스펙으로 정렬을 구현할 수도 있고, Sort 객체를 사용할 수도 있습니다.
+        val sort =
+            when (sortType) {
+                1 -> Sort.by(Sort.Direction.ASC, "title") // 간단히 title로 '정확도' 대체
+                2 -> Sort.by(Sort.Direction.ASC, "dates") // 공연일자 중 가장 빠른 날짜
+                3 -> Sort.by(Sort.Direction.DESC, "sales") // 'sales' 컬럼이 있다고 가정
+                else -> Sort.by(Sort.Direction.ASC, "title") // 기본 정렬
+            }
+
+        // repository 호출
+        val performanceEntities = performanceRepository.findAll(spec, sort)
+
+        // DTO 변환
+        return performanceEntities.map { Performance.fromEntity(it) }
+    }
+
+    fun createPerformance(performance: Performance): Performance {
+        TODO()
+    }
+
+    fun editPerformance(performance: Performance): Performance {
+        TODO()
+    }
+
+    fun deletePerformance(performance: Performance) {
+        TODO()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/interpark/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/review/controller/ReviewController.kt
@@ -1,2 +1,1 @@
 package com.wafflestudio.interpark.review.controller
-

--- a/src/main/kotlin/com/wafflestudio/interpark/review/persistence/ReviewEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/review/persistence/ReviewEntity.kt
@@ -1,4 +1,3 @@
 package com.wafflestudio.interpark.review.persistence
 
-class ReviewEntity {
-}
+class ReviewEntity

--- a/src/main/kotlin/com/wafflestudio/interpark/review/service/ReviewService.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/review/service/ReviewService.kt
@@ -1,4 +1,3 @@
 package com.wafflestudio.interpark.review.service
 
-class ReviewService {
-}
+class ReviewService

--- a/src/main/kotlin/com/wafflestudio/interpark/seat/controller/SeatController.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/seat/controller/SeatController.kt
@@ -1,2 +1,1 @@
 package com.wafflestudio.interpark.seat.controller
-

--- a/src/main/kotlin/com/wafflestudio/interpark/user/persistence/UserIdentityEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/user/persistence/UserIdentityEntity.kt
@@ -1,6 +1,10 @@
 package com.wafflestudio.interpark.user.persistence
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
 
 @Entity
 class UserIdentityEntity(
@@ -9,5 +13,4 @@ class UserIdentityEntity(
     val id: String? = null,
     @Column(name = "hashedPassword", nullable = false)
     val hashedPassword: String,
-) {
-}
+)

--- a/src/main/kotlin/com/wafflestudio/interpark/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/interpark/user/service/UserService.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.interpark.user.service
 
-import com.wafflestudio.interpark.user.*
 import com.wafflestudio.interpark.user.controller.User
 import com.wafflestudio.interpark.user.persistence.UserEntity
 import com.wafflestudio.interpark.user.persistence.UserRepository
@@ -19,7 +18,7 @@ class UserService(
         phoneNumber: String,
         email: String,
     ): User {
-        //TODO : 회원가입 기능 만들기
+        // TODO : 회원가입 기능 만들기
         val user =
             userRepository.save(
                 UserEntity(


### PR DESCRIPTION
공연 검색 파라미터가 주어졌을 때 이를 기준으로 공연 리스트를 반환하는 검색 기능을 구현했습니다.

필수 파라미터: 검색어, 정렬기준
옵션 파라미터: 날짜, 지역, 장르

이 때, 정렬기준 중 '정확도순'은 아직 단어의 정확도 스코어를 계산하기 어려워서 일단은 공연 제목 오름차순 정렬로 구현했습니다.